### PR TITLE
Changed homebrew/cask-cask to homebrew/cask

### DIFF
--- a/mac
+++ b/mac
@@ -39,7 +39,7 @@ brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"
-tap "homebrew/cask-cask"
+tap "homebrew/cask"
 
 # Unix
 brew "git"


### PR DESCRIPTION
The `tap "homebrew/cask-cask"` causes the homebrew to try pull https://github.com/Homebrew/homebrew-cask-cask/ which doesn't exist. After the change I was able to run the script without errors.

I'm not sure if the whole line is even necessary anymore as I think the cask functionality used to be an external addition to homebrew but comes bundled with the latest versions of homebrew.