### PR TITLE
Change homebrew/cask-cask to homebrew/homebrew-cask

### DIFF
--- a/mac
+++ b/mac
@@ -39,7 +39,7 @@ brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"
-tap "homebrew/cask-cask"
+tap "homebrew/homebrew-cask"
 
 # Unix
 brew "git"


### PR DESCRIPTION
The repository is now located at https://github.com/Homebrew/homebrew-cask, so the old path of cask-cask errors when running the script